### PR TITLE
Attached script to wandering Azurill in Oldale

### DIFF
--- a/data/maps/OldaleTown/map.json
+++ b/data/maps/OldaleTown/map.json
@@ -144,7 +144,7 @@
       "movement_range_y": 3,
       "trainer_type": "TRAINER_TYPE_NONE",
       "trainer_sight_or_berry_tree_id": "0",
-      "script": "NULL",
+      "script": "OldaleTown_EventScript_Azurill",
       "flag": "0"
     },
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The wandering Azurill in Oldale Town did not have it's script attached to it resulting in no text when trying to interact with it. Script has now been added.